### PR TITLE
adapt launch config samples for Eclipse 2024-03 as "Running TP"

### DIFF
--- a/bundles/org.eclipse.tea.samples/launches/base.lc
+++ b/bundles/org.eclipse.tea.samples/launches/base.lc
@@ -13,7 +13,5 @@ abstract eclipse configuration TEA-Sample-Base {
 	feature org.eclipse.pde;
 	feature org.eclipse.jdt;
 	
-	feature org.eclipse.sdk;
-	
 	plugin org.eclipse.tea.samples;
 }

--- a/bundles/org.eclipse.tea.samples/launches/ide.lc
+++ b/bundles/org.eclipse.tea.samples/launches/ide.lc
@@ -1,8 +1,11 @@
 eclipse configuration TEA-Sample-IDE : TEA-Sample-Base {
-	product org.eclipse.sdk.ide;
+	product org.eclipse.platform.ide;
 	
 	optional feature org.eclipse.e4.tools.spies.feature;
 	optional feature org.eclipse.tea.samples.all;
+
+	plugin org.eclipse.ui.ide.application;
+	plugin org.eclipse.platform;
 	
 	workspace "${workspace_loc}/runtime-ws/tea-ide";
 }

--- a/sites/org.eclipse.tea.repository/eclipse-2023-12.target
+++ b/sites/org.eclipse.tea.repository/eclipse-2023-12.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse 2023-12" sequenceNumber="1708701430">
+<target name="Eclipse 2023-12" sequenceNumber="1709645077">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.gson" version="2.10.1.v20230109-0753"/>
@@ -17,11 +17,12 @@
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.ease.feature.feature.group" version="0.9.0.I202206140954"/>
       <unit id="org.eclipse.ease.ui.feature.feature.group" version="0.9.0.I202207260937"/>
+      <unit id="org.eclipse.ease.python.jython.feature.feature.group" version="0.9.0.I202206141122"/>
       <repository location="https://download.eclipse.org/ease/release/0.9.0/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.wamas.ide.launching.feature.feature.group" version="0.5.0.N202402221544"/>
-      <repository location="jar:https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/lcdsl_site-0.5.0.N202402221544.zip!/"/>
+      <repository location="https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/"/>
     </location>
     <location includeDependencyDepth="infinite" includeDependencyScopes="compile,test" includeSource="true" missingManifest="generate" type="Maven" label="javax">
     <dependencies>

--- a/sites/org.eclipse.tea.repository/eclipse-2023-12.tpd
+++ b/sites/org.eclipse.tea.repository/eclipse-2023-12.tpd
@@ -16,9 +16,10 @@ location "https://download.eclipse.org/releases/2023-12/" {
 location "https://download.eclipse.org/ease/release/0.9.0/" {
 	org.eclipse.ease.feature.feature.group
 	org.eclipse.ease.ui.feature.feature.group
+	org.eclipse.ease.python.jython.feature.feature.group
 }
 
-location "jar:https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/lcdsl_site-0.5.0.N202402221544.zip!/" {
+location "https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/" {
 	com.wamas.ide.launching.feature.feature.group
 }
 

--- a/sites/org.eclipse.tea.repository/target-platform.target
+++ b/sites/org.eclipse.tea.repository/target-platform.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse 2021-12" sequenceNumber="1708701531">
+<target name="Eclipse 2021-12" sequenceNumber="1709645099">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.ide" version="4.22.0.I20211124-1800"/>
@@ -38,11 +38,12 @@
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.ease.feature.feature.group" version="0.9.0.I202206140954"/>
       <unit id="org.eclipse.ease.ui.feature.feature.group" version="0.9.0.I202207260937"/>
+      <unit id="org.eclipse.ease.python.jython.feature.feature.group" version="0.9.0.I202206141122"/>
       <repository location="https://download.eclipse.org/ease/release/0.9.0/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.wamas.ide.launching.feature.feature.group" version="0.5.0.N202402221544"/>
-      <repository location="jar:https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/lcdsl_site-0.5.0.N202402221544.zip!/"/>
+      <repository location="https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/"/>
     </location>
   </locations>
 </target>

--- a/sites/org.eclipse.tea.repository/target-platform.tpd
+++ b/sites/org.eclipse.tea.repository/target-platform.tpd
@@ -38,8 +38,9 @@ location "https://download.eclipse.org/releases/2021-12/" {
 location "https://download.eclipse.org/ease/release/0.9.0/" {
 	org.eclipse.ease.feature.feature.group
 	org.eclipse.ease.ui.feature.feature.group
+	org.eclipse.ease.python.jython.feature.feature.group
 }
 
-location "jar:https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/lcdsl_site-0.5.0.N202402221544.zip!/" {
+location "https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/" {
 	com.wamas.ide.launching.feature.feature.group
 }


### PR DESCRIPTION
Adapt predefined Target Platforms to avoid Xtext errors (LcDSL) when building within Eclipse (PDE build), even if launching the samples works with "Eclipse for Committers" as Target Platform only.