### PR TITLE
Switch from File to IFile for DBAL Generator

### DIFF
--- a/bundles/org.eclipse.tea.library.build/src/org/eclipse/tea/library/build/model/FeatureData.java
+++ b/bundles/org.eclipse.tea.library.build/src/org/eclipse/tea/library/build/model/FeatureData.java
@@ -64,7 +64,7 @@ public class FeatureData extends BundleData {
 	 * @param bvService
 	 */
 	public FeatureData(IProject project, TeaBuildVersionService bvService) {
-		super(project.getName(), project.getLocation().toFile(), true, null);
+		super(project.getName(), project.findMember(project.getProjectRelativePath()), true, null);
 		this.project = project;
 		this.bvService = bvService;
 		this.document = readFeatureXml();

--- a/bundles/org.eclipse.tea.library.build/src/org/eclipse/tea/library/build/model/ManifestHolder.java
+++ b/bundles/org.eclipse.tea.library.build/src/org/eclipse/tea/library/build/model/ManifestHolder.java
@@ -27,6 +27,7 @@ import java.util.TreeMap;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.tea.library.build.internal.Activator;
 
@@ -54,7 +55,25 @@ final class ManifestHolder {
 		this.referenceFile = referenceFile;
 	}
 
+	private ManifestHolder(final Manifest manifest, final IFile referenceFile) {
+		final Attributes attr = manifest.getMainAttributes();
+		for (Object key : attr.keySet()) {
+			final String name = key.toString();
+			final String[] values = splitList(attr, name);
+			attributes.put(name, new ManifestAttribute(name, values));
+		}
+
+		this.referenceFile = referenceFile.getLocation().toFile();
+	}
+
 	static ManifestHolder fromManifest(Manifest manifest, File manifestFile) {
+		if (manifest == null) {
+			return null;
+		}
+		return new ManifestHolder(manifest, manifestFile);
+	}
+
+	static ManifestHolder fromManifest(Manifest manifest, IFile manifestFile) {
 		if (manifest == null) {
 			return null;
 		}


### PR DESCRIPTION
- Update methods to use org.eclipse.core.resources.IFile instead of java.io.File
- Modified ManifestHolder constructors to accept IFile