### PR TITLE
Add maven property for build qualifier

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--Dtycho-version=4.0.6
+-Dtycho-version=4.0.10

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,13 +12,25 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh """
-                set -xe
-                mvn clean verify
+                sh '''
+                set -xeu
+                withOfficialSuffix=
+                if [[ ${TAG_NAME-} == v* ]] \
+                && [[ ${JOB_NAME-} == "continuous/${TAG_NAME-}" ]] \
+                && [[ $(git rev-parse refs/tags/${TAG_NAME-}) == "$(git rev-parse HEAD)" ]] \
+                ; then
+                    withOfficialSuffix='-DunofficialSuffix='
+                elif [[ ${BRANCH_NAME-} == master ]] \
+                && [[ ${JOB_NAME-} == "continuous/${BRANCH_NAME-}" ]] \
+                && [[ $(git rev-parse refs/remotes/origin/${BRANCH_NAME-}) == "$(git rev-parse HEAD)" ]] \
+                ; then
+                    withOfficialSuffix='-DunofficialSuffix='
+                fi
+                mvn clean verify ${withOfficialSuffix}
                 ! test -r ./p2
                 mv sites/org.eclipse.tea.repository/target/repository p2
                 test -r ./p2/.
-                """
+                '''
             }
             post {
                 success {

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <qualifier>Alpha</qualifier>
-    <buildDate>yyyyMMddHHmm</buildDate>
-    <tycho.buildqualifier.format>'${qualifier}'-${buildDate}</tycho.buildqualifier.format>
+    <unofficialSuffix>'-UNOFFICIAL'</unofficialSuffix>
   </properties>
   
   <modules>
@@ -80,11 +78,10 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
-        <extensions>true</extensions>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>
-            <phase>package</phase>
+            <phase>verify</phase>
             <goals>
               <goal>p2-metadata</goal>
             </goals>
@@ -120,6 +117,30 @@
             <file>../../sites/org.eclipse.tea.repository/eclipse-2022-12.target</file>
           </target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-packaging-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>tycho-buildtimestamp-jgit</artifactId>
+            <version>${tycho-version}</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <timestampProvider>jgit</timestampProvider>
+          <jgit.ignore>pom.xml .gitignore .launchers/**</jgit.ignore>
+          <jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
+          <format>yyyyMMddHHmm${unofficialSuffix}</format>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-update-consumer-pom</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
   <artifactId>parent</artifactId>
   <version>2.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
+
+  <properties>
+    <qualifier>Alpha</qualifier>
+    <buildDate>yyyyMMddHHmm</buildDate>
+    <tycho.buildqualifier.format>'${qualifier}'-${buildDate}</tycho.buildqualifier.format>
+  </properties>
   
   <modules>
     <module>bundles</module>


### PR DESCRIPTION
The desired build qualifier can now be passed via command line and also includes the current date. Without any flags, the build qualifier defaults to "Alpha" and the current date.

Examples:
- `mvn clean verify` → "org.eclipse.tea.core_2.0.1.Alpha-202410171235.jar"
- `mvn clean verify -Dqualifier=Beta` → "org.eclipse.tea.core_2.0.1.Beta-202410171235.jar"
- `mvn clean verify "-Dtycho.buildqualifier.format='Final'"` → "org.eclipse.tea.core_2.0.1.Final.jar"
