### PR TITLE
Update required LCDSL version to 1.0.0.

### DIFF
--- a/sites/org.eclipse.tea.repository/eclipse-2024-09.target
+++ b/sites/org.eclipse.tea.repository/eclipse-2024-09.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse 2024-09" sequenceNumber="1744202967">
+<target name="Eclipse 2024-09" sequenceNumber="1744717416">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.gson" version="2.11.0"/>
@@ -56,8 +56,8 @@
       <repository location="https://download.eclipse.org/tracecompass.incubator/2021-06/master/rcp-repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="com.wamas.ide.launching.feature.feature.group" version="0.5.0.N202402221544"/>
-      <repository location="https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/"/>
+      <unit id="com.wamas.ide.launching.feature.feature.group" version="1.0.0.202504011345-UNOFFICIAL"/>
+      <repository location="https://github.com/ssi-schaefer/lcdsl/releases/download/1.0.0/"/>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>

--- a/sites/org.eclipse.tea.repository/eclipse-2024-09.tpd
+++ b/sites/org.eclipse.tea.repository/eclipse-2024-09.tpd
@@ -62,6 +62,6 @@ location "https://download.eclipse.org/tracecompass.incubator/2021-06/master/rcp
 	org.jython
 }
 
-location "https://github.com/ssi-schaefer/lcdsl/releases/download/0.5.0/" {
+location "https://github.com/ssi-schaefer/lcdsl/releases/download/1.0.0/" {
 	com.wamas.ide.launching.feature.feature.group
 }


### PR DESCRIPTION
This resolves a code-level incompatibility when using TEA 3.0.0 in combination with LCDSL 1.0.0.