### PR TITLE
No longer generate source-features as they are deprecated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
           </execution>
           <execution>
             <id>feature-source</id>
+            <phase>none</phase>
             <goals>
               <goal>feature-source</goal>
             </goals>

--- a/sites/org.eclipse.tea.repository/category.xml
+++ b/sites/org.eclipse.tea.repository/category.xml
@@ -3,32 +3,17 @@
   <feature id="org.eclipse.tea.core_feature">
     <category name="tea.core.id"/>
   </feature>
-  <feature id="org.eclipse.tea.core_feature.source">
-    <category name="tea.dev.id"/>
-  </feature>
   <feature id="org.eclipse.tea.ui_feature">
     <category name="tea.core.id"/>
-  </feature>
-  <feature id="org.eclipse.tea.ui_feature.source">
-    <category name="tea.dev.id"/>
   </feature>
   <feature id="org.eclipse.tea.scripting_feature">
     <category name="tea.ease.id"/>
   </feature>
-  <feature id="org.eclipse.tea.scripting_feature.source">
-    <category name="tea.dev.id"/>
-  </feature>
   <feature id="org.eclipse.tea.library_feature">
     <category name="tea.library.id"/>
   </feature>
-  <feature id="org.eclipse.tea.library_feature.source">
-    <category name="tea.dev.id"/>
-  </feature>
   <feature id="org.eclipse.tea.lcdsl.library_feature">
     <category name="tea.lcdsl.id"/>
-  </feature>
-  <feature id="org.eclipse.tea.lcdsl.library_feature.source">
-    <category name="tea.dev.id"/>
   </feature>
   <category-def name="tea.core.id" label="TEA Core (incubation)">
     <description>
@@ -48,11 +33,6 @@
   <category-def name="tea.lcdsl.id" label="TEA LcDsl Library Integration (incubation)">
     <description>
       TEA LcDsl integration extensions for TEA library
-    </description>
-  </category-def>
-  <category-def name="tea.dev.id" label="TEA Developer Resources (incubation)">
-    <description>
-      Source bundles for all TEA bundles.
     </description>
   </category-def>
 </site>


### PR DESCRIPTION
Since having upgraded to a newer tycho version, new warnings are shown indicating that source-features are deprecated and will be removed in a future tycho release. Additionally, source-features have led to sporadic failures during the CI build. Therefore I think it's best to no longer generate source-features.