### PR TITLE
add target definitions for 2025-12

### DIFF
--- a/sites/org.eclipse.tea.repository/eclipse-2025-12.target
+++ b/sites/org.eclipse.tea.repository/eclipse-2025-12.target
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde?>
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="Eclipse 2025-12" sequenceNumber="1765894592">
+  <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="com.google.gson" version="2.13.2"/>
+      <unit id="com.google.guava" version="33.5.0.jre"/>
+      <unit id="com.google.inject" version="7.0.0"/>
+      <unit id="io.github.classgraph.classgraph" version="4.8.184"/>
+      <unit id="com.googlecode.javaewah.JavaEWAH" version="1.2.3"/>
+      <unit id="org.aopalliance" version="1.0.0.v20230720-0728"/>
+      <unit id="org.apache.commons.codec" version="1.14.0.v20221112-0806"/>
+      <unit id="org.apache.commons.commons-io" version="2.21.0"/>
+      <unit id="org.apache.commons.logging" version="1.2.0"/>
+      <unit id="org.apache.httpcomponents.httpclient" version="4.5.14"/>
+      <unit id="org.apache.httpcomponents.httpcore" version="4.4.16"/>
+      <unit id="org.apache.log4j" version="1.2.26"/>
+      <unit id="org.apache.sshd.osgi" version="2.16.0"/>
+      <unit id="org.apache.sshd.sftp" version="2.16.0"/>
+      <unit id="org.eclipse.draw2d.feature.group" version="3.26.0.202512020742"/>
+      <unit id="org.eclipse.e4.ui.progress" version="0.4.900.v20251023-1511"/>
+      <unit id="org.eclipse.e4.tools.emf.ui" version="4.8.900.v20251023-0833"/>
+      <unit id="org.eclipse.e4.tools.services" version="4.10.600.v20240801-2123"/>
+      <unit id="org.eclipse.ecf" version="3.13.0.v20250304-2338"/>
+      <unit id="org.eclipse.ecf.identity" version="3.10.0.v20240812-1535"/>
+      <unit id="org.eclipse.ecf.filetransfer" version="5.1.103.v20230705-0614"/>
+      <unit id="org.eclipse.egit.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.44.0.v20251106-1447"/>
+      <unit id="org.eclipse.jgit.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.jgit.lfs.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="7.5.0.202512021534-r"/>
+      <unit id="org.eclipse.m2e.feature.feature.group" version="2.10.0.20251127-1007"/>
+      <unit id="org.eclipse.sdk.feature.group" version="4.38.0.v20251201-1407"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="2.41.0.v20251124-0739"/>
+      <unit id="org.objectweb.asm" version="9.9.0"/>
+      <unit id="org.objectweb.asm.tree" version="9.9.0"/>
+      <unit id="org.sat4j.core" version="2.3.6.v20201214"/>
+      <unit id="org.sat4j.pb" version="2.3.6.v20201214"/>
+      <unit id="slf4j.api" version="2.0.17"/>
+      <repository location="https://download.eclipse.org/releases/2025-12/202512101000/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.ease.feature.feature.group" version="0.10.0.I202312181133"/>
+      <unit id="org.eclipse.ease.lang.python.feature.feature.group" version="0.10.0.I202312050748"/>
+      <unit id="org.eclipse.ease.ui.feature.feature.group" version="0.10.0.I202512150422"/>
+      <unit id="org.eclipse.ease.python.jython.feature.feature.group" version="0.10.0.I202312050748"/>
+      <repository location="https://download.eclipse.org/ease/integration/nightly/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.jython" version="2.7.0.I202104151016"/>
+      <repository location="https://download.eclipse.org/tracecompass.incubator/2024-12/master/rcp-repository"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="com.wamas.ide.launching.feature.feature.group" version="1.1.0.202510271002"/>
+      <repository location="https://github.com/ssi-schaefer/lcdsl/releases/download/1.1.0/"/>
+    </location>
+  </locations>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+</target>

--- a/sites/org.eclipse.tea.repository/eclipse-2025-12.tpd
+++ b/sites/org.eclipse.tea.repository/eclipse-2025-12.tpd
@@ -1,0 +1,65 @@
+target "Eclipse 2025-12"
+
+with source requirements
+environment JavaSE-21
+
+location "https://download.eclipse.org/releases/2025-12/202512101000/" {
+	com.google.gson
+	com.google.guava [33,34)
+	com.google.inject
+
+	io.github.classgraph.classgraph
+	com.googlecode.javaewah.JavaEWAH
+
+	org.aopalliance
+
+	org.apache.commons.codec
+	org.apache.commons.commons-io
+	org.apache.commons.logging
+	org.apache.httpcomponents.httpclient
+	org.apache.httpcomponents.httpcore
+	org.apache.log4j
+	org.apache.sshd.osgi
+	org.apache.sshd.sftp
+
+	org.eclipse.draw2d.feature.group
+	org.eclipse.e4.ui.progress
+	org.eclipse.e4.tools.emf.ui
+	org.eclipse.e4.tools.services
+	org.eclipse.ecf
+	org.eclipse.ecf.identity
+	org.eclipse.ecf.filetransfer
+	org.eclipse.egit.feature.group
+	org.eclipse.emf.feature.group
+	org.eclipse.jgit.feature.group
+	org.eclipse.jgit.gpg.bc.feature.group
+	org.eclipse.jgit.http.apache.feature.group
+	org.eclipse.jgit.lfs.feature.group
+	org.eclipse.jgit.ssh.apache.feature.group
+	org.eclipse.m2e.feature.feature.group
+	org.eclipse.sdk.feature.group
+	org.eclipse.xtext.sdk.feature.group
+
+	org.objectweb.asm
+	org.objectweb.asm.tree
+
+	org.sat4j.core
+	org.sat4j.pb
+
+	slf4j.api
+}
+
+location "https://download.eclipse.org/ease/integration/nightly/" {
+	org.eclipse.ease.feature.feature.group
+	org.eclipse.ease.lang.python.feature.feature.group
+	org.eclipse.ease.ui.feature.feature.group
+	org.eclipse.ease.python.jython.feature.feature.group
+}
+
+location "https://download.eclipse.org/tracecompass.incubator/2024-12/master/rcp-repository" {
+	org.jython
+}
+
+location "https://github.com/ssi-schaefer/lcdsl/releases/download/1.1.0/" {
+	com.wamas.ide.launching.feature.feature.group
+}


### PR DESCRIPTION
TEA seems compatible still, no code changes required: Stick to 2024-09 for build, as well as default selected by Oomph.