### PR TITLE
import javax.annotation and java.inject with minimum version

### DIFF
--- a/bundles/org.eclipse.tea.core.ui.live/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.tea.core.ui.live/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.google.guava,
  org.eclipse.core.resources
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
+Import-Package: javax.annotation;version="1.3.5",
   javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.tea.core.ui.live.internal.Activator

--- a/bundles/org.eclipse.tea.core.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.tea.core.ui/META-INF/MANIFEST.MF
@@ -55,7 +55,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.core.di.extensions
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation,
+Import-Package: javax.annotation;version="1.3.5",
  org.eclipse.e4.ui.css.swt.theme,
  javax.inject;version="1.0.0"
 Service-Component: OSGI-INF/org.eclipse.tea.core.ui.DevelopmentMenuDecoration.xml,

--- a/bundles/org.eclipse.tea.library.build.lcdsl/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.tea.library.build.lcdsl/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.resources,
  com.wamas.ide.launching.ui,
  org.eclipse.tea.core.ui
 Import-Package: com.google.common.base,
- javax.inject
+ javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.tea.library.build.lcdsl.tasks,
  org.eclipse.tea.library.build.lcdsl.tasks.chains,

--- a/bundles/org.eclipse.tea.library.build/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.tea.library.build/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.m2e.maven.runtime,
  org.eclipse.equinox.p2.director.app,
  org.eclipse.jdt.apt.core
-Import-Package: javax.inject
+Import-Package: javax.inject;version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.tea.library.build.chain,
  org.eclipse.tea.library.build.chain.plugin,


### PR DESCRIPTION
to depend on the jakarta-api bundles providing the javax APIs. Otherwise, we may end up with the old javax bundles, failing to classload the javax annotations at runtime.